### PR TITLE
Fix DataTables horizontal scroll behavior

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@ body {
   flex: 1;
   background: #fbfcfd;
   border-radius: 0 0 12px 12px;
-  overflow-x: auto;
+  overflow-x: hidden;
   /* padding: 0; // 表格需要貼邊就不要 padding */
 }
 #file-content > table.dataTable {
@@ -270,60 +270,40 @@ body {
   .main-grid { margin: 8px 0; }
 }
 
-  
 .table-scroll-wrapper {
   overflow-x: auto;
   width: 100%;
 }
-body {
-  overflow-x: hidden;
-}
-.table-scroll-wrapper {
-  overflow-x: auto;
-  width: 100%;
-}
+
 .table-scroll-wrapper table {
   min-width: 0;
   width: max-content;
   table-layout: fixed;
 }
 
-}
-/* Fixed top/bottom controls */
-.table-controls-top,
-.table-controls-bottom {
-  background: #fff;
-  padding: 0 1rem;
-  z-index: 5;
-  white-space: nowrap;
-}
-.table-controls-top {
-  margin-bottom: 0.5rem;
-}
-.table-controls-bottom {
-  margin-top: 0.5rem;
+body {
+  overflow-x: hidden;
 }
 
-
-/* Fixed top/bottom controls sticky positioning */
 .table-controls-top,
 .table-controls-bottom {
-  position: sticky !important;
-  left: 0;
   background: #fff;
   padding: 0 1rem;
   z-index: 10;
   white-space: nowrap;
+  position: sticky;
+  left: 0;
 }
+
 .table-controls-top {
   top: 0;
   margin-bottom: 0.5rem;
 }
+
 .table-controls-bottom {
   bottom: 0;
   margin-top: 0.5rem;
 }
-
 </style>
 </head>
 <body>
@@ -565,11 +545,12 @@ function loadFileContent(filename) {
           paging: true,
           searching: true,
           ordering: true,
-          
+
           responsive: false,
           autoWidth: true,
-          dom: 'lfrtip'
+          dom: '<"table-controls-top"lf>rt<"table-controls-bottom"ip>'
         });
+        table.wrap('<div class="table-scroll-wrapper"></div>');
         let searchInput = $('div.dataTables_filter input');
         searchInput.off('input.dt').on('input.dt', function() {
           currentTable.search(this.value).draw();

--- a/tests/test_scroll_behavior.py
+++ b/tests/test_scroll_behavior.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import re
+from lxml import html
+
+def test_css_and_js_present():
+    data = Path('templates/index.html').read_text()
+    assert re.search(r'\.main-content-body\s*{[^}]*overflow-x:\s*hidden', data)
+    assert re.search(r'\.table-scroll-wrapper\s*{[^}]*overflow-x:\s*auto', data)
+    assert re.search(r"dom:\s*'<\"table-controls-top\"lf>rt<\"table-controls-bottom\"ip>'", data)
+    assert "table.wrap('<div class=\"table-scroll-wrapper\"></div>');" in data
+    assert re.search(r'\.table-controls-top,\n\.table-controls-bottom\s*{[^}]*position:\s*sticky', data)
+
+def test_controls_not_in_scroll_area():
+    snippet = '''
+    <div class="dataTables_wrapper">
+      <div class="table-controls-top"></div>
+      <div class="table-scroll-wrapper"><table></table></div>
+      <div class="table-controls-bottom"></div>
+    </div>
+    '''
+    doc = html.fromstring(snippet)
+    scroll = doc.xpath('//*[@class="table-scroll-wrapper"]')[0]
+    top = doc.xpath('//*[@class="table-controls-top"]')[0]
+    bottom = doc.xpath('//*[@class="table-controls-bottom"]')[0]
+    assert top not in scroll.iterdescendants()
+    assert bottom not in scroll.iterdescendants()
+


### PR DESCRIPTION
## Summary
- prevent outer container from scrolling horizontally and add dedicated `.table-scroll-wrapper` around DataTables table
- keep search and pagination controls fixed using custom DOM structure and sticky styling
- add tests verifying CSS and DOM structure for the new layout

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a2496da4832d865d549a55e171f8